### PR TITLE
Feature/8 maintain spec count on leave

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36'
+def runeLiteVersion = '1.7.5'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -19,14 +19,12 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
 	testImplementation 'junit:junit:4.12'
-	testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
-		exclude group: 'ch.qos.logback', module: 'logback-classic'
-	}
+	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'com.example'
-version = '1.0-SNAPSHOT'
+version = '1.1.0'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/corpffa/CorpFfaConfig.java
+++ b/src/main/java/com/corpffa/CorpFfaConfig.java
@@ -147,6 +147,16 @@ public interface CorpFfaConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "hideBanner",
+            name = "Hide \"Corp FFA\" Banner",
+            description = "Should the \"Corp FFA\" banner be hidden?",
+            section = hidingSection
+    )
+    default boolean hideBanner() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "hideTeledPlayers",
             name = "Hide Teled Players",
             description = "Should teled/dead players be hidden in the player list?",

--- a/src/main/java/com/corpffa/CorpFfaConfig.java
+++ b/src/main/java/com/corpffa/CorpFfaConfig.java
@@ -53,7 +53,7 @@ public interface CorpFfaConfig extends Config {
             section = colorsSection
     )
     default Color rangerColor() {
-        return Color.PINK;
+        return Color.RED;
     }
 
     @ConfigItem(
@@ -127,16 +127,6 @@ public interface CorpFfaConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "hideRangers",
-            name = "Hide Rangers",
-            description = "Should rangers be shown in the player list?",
-            section = hidingSection
-    )
-    default boolean hideRangers() {
-        return false;
-    }
-
-    @ConfigItem(
             keyName = "hidePlayerCount",
             name = "Hide Player Count",
             description = "Should the player count be hidden?",
@@ -163,26 +153,6 @@ public interface CorpFfaConfig extends Config {
             section = hidingSection
     )
     default boolean hideTeledPlayers() {
-        return false;
-    }
-
-    @ConfigItem(
-            keyName = "groupRangers",
-            name = "Group Rangers",
-            description = "Should the rangers be shown together in the player list?",
-            section = generalSection
-    )
-    default boolean groupRangers() {
-        return false;
-    }
-
-    @ConfigItem(
-            keyName = "splitRangersInPlayerCount",
-            name = "Split Rangers In Player Count",
-            description = "Should the rangers count be shown separately in the player count e.g 20 (+2)?",
-            section = generalSection
-    )
-    default boolean splitRangersInPlayerCount() {
         return false;
     }
 

--- a/src/main/java/com/corpffa/CorpFfaOverlay.java
+++ b/src/main/java/com/corpffa/CorpFfaOverlay.java
@@ -125,7 +125,6 @@ public class CorpFfaOverlay extends OverlayPanel {
                 leftColor = goneColor;
                 rightColor = goneColor;
 
-                rightLabel = "-";
                 if (config.hideTeledPlayers()) {
                     shouldRender = false;
                 }

--- a/src/main/java/com/corpffa/CorpFfaOverlay.java
+++ b/src/main/java/com/corpffa/CorpFfaOverlay.java
@@ -55,17 +55,6 @@ public class CorpFfaOverlay extends OverlayPanel {
         playerStates.sort((player1, player2) -> {
             String playerName1 = player1.getKey();
             String playerName2 = player2.getKey();
-            CorpFfaPlugin.PlayerState playerState1 = player1.getValue();
-            CorpFfaPlugin.PlayerState playerState2 = player2.getValue();
-
-            if (config.groupRangers() && !(playerState1.IsRanger && playerState2.IsRanger)) {
-                if (playerState1.IsRanger) {
-                    return playerName1.compareToIgnoreCase("0000000000000000");
-                }
-                if (playerState2.IsRanger) {
-                    return "0000000000000000".compareToIgnoreCase(playerName2);
-                }
-            }
 
             return playerName1.compareToIgnoreCase(playerName2);
         });
@@ -107,7 +96,7 @@ public class CorpFfaOverlay extends OverlayPanel {
             boolean hasBannedGear = playerState.BannedGear.size() > 0;
             boolean hasSpecced = playerState.SpecCount >= 2;
             boolean allGood = !hasBannedGear && hasSpecced;
-            boolean isNonSpeccer = !hasSpecced && shouldHaveSpecced && !playerState.IsRanger;
+            boolean isNonSpeccer = !hasSpecced && shouldHaveSpecced;
 
             String rightLabel = playerState.SpecCount + "";
             Color rightColor = config.defaultColor();
@@ -154,17 +143,6 @@ public class CorpFfaOverlay extends OverlayPanel {
                     String acronym = Arrays.stream(weaponName.split(" ")).map(str -> str.substring(0, 1)).collect(Collectors.joining(""));
 
                     highlightText += "( " + acronym + ")";
-                }
-
-
-            } else if (playerState.IsRanger) {
-                Color rangerColor = config.rangerColor();
-                leftColor = rangerColor;
-                rightColor = rangerColor;
-                rightLabel = "Ranger";
-
-                if (config.hideRangers()) {
-                    shouldRender = false;
                 }
 
             } else if (allGood) {
@@ -216,11 +194,6 @@ public class CorpFfaOverlay extends OverlayPanel {
 
         if (showCount) {
             playerCountText = playerCount + "";
-        }
-
-        if (showCount && config.splitRangersInPlayerCount()) {
-            long rangerCount = playersInCave.stream().filter(o -> o.IsRanger).count();
-            playerCountText = (playerCount - rangerCount) + " (+" + rangerCount + ")";
         }
 
         renderableEntities.add(

--- a/src/main/java/com/corpffa/CorpFfaOverlay.java
+++ b/src/main/java/com/corpffa/CorpFfaOverlay.java
@@ -41,7 +41,7 @@ public class CorpFfaOverlay extends OverlayPanel {
         renderableEntities.clear();
         Rectangle overlayPosition = super.getBounds();
 
-        List<Entry<String, CorpFfaPlugin.PlayerState>> playerStates = new ArrayList<>(plugin.PlayersInCave.entrySet());
+        List<Entry<String, PlayerState>> playerStates = new ArrayList<>(plugin.PlayersInCave.entrySet());
 
         if (playerStates.size() <= 1) {
             return super.render(graphics2D);
@@ -83,9 +83,9 @@ public class CorpFfaOverlay extends OverlayPanel {
      * @param playerStates
      * @param shouldHaveSpecced  Are players expected to have specced yet?
      */
-    private void drawPlayerList(Graphics2D graphics2D, List<LayoutableRenderableEntity> renderableEntities, Rectangle overlayPosition, List<Entry<String, CorpFfaPlugin.PlayerState>> playerStates, boolean shouldHaveSpecced) {
-        for (Entry<String, CorpFfaPlugin.PlayerState> entry : playerStates) {
-            CorpFfaPlugin.PlayerState playerState = entry.getValue();
+    private void drawPlayerList(Graphics2D graphics2D, List<LayoutableRenderableEntity> renderableEntities, Rectangle overlayPosition, List<Entry<String, PlayerState>> playerStates, boolean shouldHaveSpecced) {
+        for (Entry<String, PlayerState> entry : playerStates) {
+            PlayerState playerState = entry.getValue();
             Player player = playerState.Player;
             String nonFriendsChatIndicator = config.nonFriendChatLabel();
 
@@ -184,7 +184,7 @@ public class CorpFfaOverlay extends OverlayPanel {
 
     private void drawPlayerCount(List<LayoutableRenderableEntity> renderableEntities, boolean showCount) {
 
-        List<CorpFfaPlugin.PlayerState> playersInCave = plugin.PlayersInCave.values()
+        List<PlayerState> playersInCave = plugin.PlayersInCave.values()
                 .stream()
                 .filter(o -> !o.HasLeft)
                 .collect(Collectors.toList());

--- a/src/main/java/com/corpffa/CorpFfaOverlay.java
+++ b/src/main/java/com/corpffa/CorpFfaOverlay.java
@@ -70,8 +70,10 @@ public class CorpFfaOverlay extends OverlayPanel {
             return playerName1.compareToIgnoreCase(playerName2);
         });
 
+        if (!config.hideBanner()) {
+            renderableEntities.add(TitleComponent.builder().text("Corp FFA").color(config.defaultColor()).build());
+        }
 
-        renderableEntities.add(TitleComponent.builder().text("Corp FFA").color(config.defaultColor()).build());
         drawPlayerList(graphics2D, renderableEntities, overlayPosition, playerStates, shouldHaveSpecced);
 
 
@@ -90,7 +92,7 @@ public class CorpFfaOverlay extends OverlayPanel {
      * @param renderableEntities
      * @param overlayPosition
      * @param playerStates
-     * @param shouldHaveSpecced Are players expected to have specced yet?
+     * @param shouldHaveSpecced  Are players expected to have specced yet?
      */
     private void drawPlayerList(Graphics2D graphics2D, List<LayoutableRenderableEntity> renderableEntities, Rectangle overlayPosition, List<Entry<String, CorpFfaPlugin.PlayerState>> playerStates, boolean shouldHaveSpecced) {
         for (Entry<String, CorpFfaPlugin.PlayerState> entry : playerStates) {
@@ -110,7 +112,7 @@ public class CorpFfaOverlay extends OverlayPanel {
             String rightLabel = playerState.SpecCount + "";
             Color rightColor = config.defaultColor();
 
-            String leftLabel = player.getName() +  (player.isFriendsChatMember() ? "" : " " + nonFriendsChatIndicator);
+            String leftLabel = player.getName() + (player.isFriendsChatMember() ? "" : " " + nonFriendsChatIndicator);
             Color leftColor = config.defaultColor();
 
             Color highlightColor = null;

--- a/src/main/java/com/corpffa/CorpFfaPlugin.java
+++ b/src/main/java/com/corpffa/CorpFfaPlugin.java
@@ -356,31 +356,6 @@ public class CorpFfaPlugin extends Plugin {
                 .collect(Collectors.toList());
     }
 
-    public static class PlayerState {
-        public int SpecCount;
-        public List<Integer> BannedGear;
-        public boolean IsRanger;
-        public boolean HasLeft;
-        public boolean IsTagged;
-        public Player Player;
-        public boolean HideFromList;
-        public boolean HasBeenScreenshotted;
-
-        public Integer Weapon;
-
-        public PlayerState(Player player) {
-            Player = player;
-            SpecCount = 0;
-            BannedGear = new ArrayList<>();
-            IsRanger = false;
-            HasLeft = false;
-            IsTagged = false;
-            HideFromList = false;
-            Weapon = -1;
-            HasBeenScreenshotted = false;
-        }
-    }
-
     private void takeScreenshot(String fileName) {
         boolean shouldNotify = config.nofifyOnCapture();
         boolean shouldCopyToClipboard = config.saveToClipboard();

--- a/src/main/java/com/corpffa/PlayerState.java
+++ b/src/main/java/com/corpffa/PlayerState.java
@@ -1,0 +1,31 @@
+package com.corpffa;
+
+import net.runelite.api.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PlayerState {
+    public int SpecCount;
+    public List<Integer> BannedGear;
+    public boolean IsRanger;
+    public boolean HasLeft;
+    public boolean IsTagged;
+    public net.runelite.api.Player Player;
+    public boolean HideFromList;
+    public boolean HasBeenScreenshotted;
+
+    public Integer Weapon;
+
+    public PlayerState(Player player) {
+        Player = player;
+        SpecCount = 0;
+        BannedGear = new ArrayList<>();
+        IsRanger = false;
+        HasLeft = false;
+        IsTagged = false;
+        HideFromList = false;
+        Weapon = -1;
+        HasBeenScreenshotted = false;
+    }
+}


### PR DESCRIPTION
- #8 Keep spec count in player list when a player leaves
- Add option to hide "Corp FFA" banner in player list
- Remove unused ranger options now that range is banned in FFA
- Bump up Runelite version